### PR TITLE
Fixed reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Dragon Egg | No alternative yet
 #### Saltpeter
 - ![](resources/assets/veganoption/textures/items/saltpeter.png) Saltpeter occasionally drops when mining Sandstone
 
-> *References: [Sodium nitrate (Chile saltpeter)](http://en.wikipedia.org/wiki/Sodium_nitrate), [Chilean caliche](http://en.wikipedia.org/wiki/Caliche#Chilean_caliche)*
+> *References: [Potassium nitrate](http://en.wikipedia.org/wiki/Potassium_nitrate), [Chilean caliche](http://en.wikipedia.org/wiki/Caliche#Chilean_caliche)*
 
 #### Sulfur
 - ![](resources/assets/veganoption/textures/items/sulfur.png) Sulfur occasionally drops when mining Netherrack


### PR DESCRIPTION
Sodium nitrate is not called Saltpeter, Potassium nitrate is.
Sodium Nitrate is far less useful for manufacturing gunpowder, and according to http://en.wikipedia.org/wiki/Caliche#Chilean_caliche, Chilean caliche also contains Potassium Nitrate (even though in far lower quantities), so that's fine.
Additionally, both Potassium and Sodium nitrate both have almost the same fertilizing properties due to both having the nitrate anion, to justify its other use.
