### PR TITLE
Allow Burlap armor to be used in place of Leather armor

### DIFF
--- a/java/squeek/veganoption/content/ContentHelper.java
+++ b/java/squeek/veganoption/content/ContentHelper.java
@@ -70,6 +70,10 @@ public class ContentHelper
 	public static final String wheatFlourOreDict = "flourWheat";
 	public static final String wheatDoughOreDict = "doughWheat";
 	public static final String rawSeitanOreDict = "seitanRaw";
+	public static final String leatherBootsOreDict = "bootsLeather";
+	public static final String leatherLeggingsOreDict = "leggingsLeather";
+	public static final String leatherChestplateOreDict = "chestplateLeather";
+	public static final String leatherHelmetOreDict = "helmetLeather";
 
 	// raw and cooked meats from HarvestCraft
 	public static final String rawMeatOreDict = "listAllmeatraw";

--- a/java/squeek/veganoption/content/modules/Burlap.java
+++ b/java/squeek/veganoption/content/modules/Burlap.java
@@ -60,6 +60,14 @@ public class Burlap implements IContentModule
 	{
 		OreDictionary.registerOre(ContentHelper.leatherOreDict, new ItemStack(Items.leather));
 		OreDictionary.registerOre(ContentHelper.leatherOreDict, new ItemStack(burlap));
+		OreDictionary.registerOre(ContentHelper.leatherBootsOreDict, new ItemStack(Items.leather_boots));
+		OreDictionary.registerOre(ContentHelper.leatherBootsOreDict, new ItemStack(burlapBoots));
+		OreDictionary.registerOre(ContentHelper.leatherLeggingsOreDict, new ItemStack(Items.leather_leggings));
+		OreDictionary.registerOre(ContentHelper.leatherLeggingsOreDict, new ItemStack(burlapLeggings));
+		OreDictionary.registerOre(ContentHelper.leatherChestplateOreDict, new ItemStack(Items.leather_chestplate));
+		OreDictionary.registerOre(ContentHelper.leatherChestplateOreDict, new ItemStack(burlapChestplate));
+		OreDictionary.registerOre(ContentHelper.leatherHelmetOreDict, new ItemStack(Items.leather_helmet));
+		OreDictionary.registerOre(ContentHelper.leatherHelmetOreDict, new ItemStack(burlapHelmet));
 	}
 
 	@Override
@@ -70,6 +78,10 @@ public class Burlap implements IContentModule
 		Modifiers.recipes.excludeOutput(new ItemStack(Items.leather_leggings));
 		Modifiers.recipes.excludeOutput(new ItemStack(Items.leather_boots));
 		Modifiers.recipes.convertInput(new ItemStack(Items.leather), ContentHelper.leatherOreDict);
+		Modifiers.recipes.convertInput(new ItemStack(Items.leather_boots), ContentHelper.leatherBootsOreDict);
+		Modifiers.recipes.convertInput(new ItemStack(Items.leather_leggings), ContentHelper.leatherLeggingsOreDict);
+		Modifiers.recipes.convertInput(new ItemStack(Items.leather_chestplate), ContentHelper.leatherChestplateOreDict);
+		Modifiers.recipes.convertInput(new ItemStack(Items.leather_helmet), ContentHelper.leatherHelmetOreDict);
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(burlap), "~~", "~~", '~', ContentHelper.bastFibreOreDict));
 


### PR DESCRIPTION
Presently, Burlap armor pieces cannot be used in crafting recipes that require Leather armor pieces. I don't think any actually exist in Vanilla, but they are used in mods moderately frequently.
