### PR TITLE
Creative Tab item/texture stuff.

### DIFF
--- a/java/squeek/veganoption/VeganOption.java
+++ b/java/squeek/veganoption/VeganOption.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Logger;
 import squeek.veganoption.content.ContentModuleHandler;
 import squeek.veganoption.content.Modifiers;
 import squeek.veganoption.content.crafting.PistonCraftingHandler;
-import squeek.veganoption.helpers.CreativeTabHelper;
 import squeek.veganoption.helpers.FluidContainerHelper;
 import squeek.veganoption.helpers.GuiHelper;
 import squeek.veganoption.helpers.TooltipHelper;
@@ -26,8 +25,8 @@ public class VeganOption
 	@Mod.Instance(ModInfo.MODID)
 	public static VeganOption instance;
 
-	// creative tab
-	public static CreativeTabs creativeTab = CreativeTabHelper.createTab(ModInfo.MODID, ModInfo.MODID_LOWER + ":creative_tab");
+	// creative tab initialized in CreativeTabProxy#create
+	public static CreativeTabs creativeTab;
 
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent event)

--- a/java/squeek/veganoption/content/ContentModuleHandler.java
+++ b/java/squeek/veganoption/content/ContentModuleHandler.java
@@ -1,6 +1,7 @@
 package squeek.veganoption.content;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -17,11 +18,13 @@ import squeek.veganoption.content.modules.compat.CompatEnderBubble;
  */
 public class ContentModuleHandler
 {
-	private static Map<String, IContentModule> modules = new HashMap<String, IContentModule>();
+	private static Map<String, IContentModule> modules = new LinkedHashMap<String, IContentModule>();
 	// TODO: resolve dependent modules for compat modules
 	private static Map<String, IContentModule> compatModules = new HashMap<String, IContentModule>();
 	static
 	{
+		// CreativeTabProxy must be first.
+		modules.put("CreativeTab", new CreativeTabProxy());
 		modules.put("Bioplastic", new Bioplastic());
 		modules.put("Burlap", new Burlap());
 		modules.put("Composting", new Composting());

--- a/java/squeek/veganoption/content/modules/CreativeTabProxy.java
+++ b/java/squeek/veganoption/content/modules/CreativeTabProxy.java
@@ -1,0 +1,50 @@
+package squeek.veganoption.content.modules;
+
+import net.minecraft.item.Item;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import squeek.veganoption.ModInfo;
+import squeek.veganoption.VeganOption;
+import squeek.veganoption.content.ContentHelper;
+import squeek.veganoption.content.IContentModule;
+import squeek.veganoption.helpers.CreativeTabHelper;
+
+public class CreativeTabProxy implements IContentModule
+{
+	public Item proxyItem;
+
+	@Override
+	public void create()
+	{
+		proxyItem = new Item()
+			.setUnlocalizedName(ModInfo.MODID + ".creative_tab")
+			.setRegistryName(ModInfo.MODID_LOWER, "creative_tab");
+		GameRegistry.register(proxyItem);
+		VeganOption.creativeTab = CreativeTabHelper.createTab(ModInfo.MODID, proxyItem);
+	}
+
+	@Override
+	public void oredict()
+	{
+	}
+
+	@Override
+	public void recipes()
+	{
+	}
+
+	@Override
+	public void finish()
+	{
+	}
+
+	@Override
+	public void clientSidePost()
+	{
+	}
+
+	@Override
+	public void clientSidePre()
+	{
+		ContentHelper.registerTypicalItemModel(proxyItem);
+	}
+}

--- a/java/squeek/veganoption/helpers/CreativeTabHelper.java
+++ b/java/squeek/veganoption/helpers/CreativeTabHelper.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -13,19 +12,9 @@ public class CreativeTabHelper
 {
 	public static final Map<String, Item> creativeTabIconItemMap = new HashMap<String, Item>();
 
-	public static class ItemCreativeTabIconProxy extends Item
+	public static CreativeTabs createTab(final String name, Item item)
 	{
-		protected ResourceLocation texture;
-		public ItemCreativeTabIconProxy(String textureName)
-		{
-			super();
-			this.texture = new ResourceLocation(textureName);
-		}
-	}
-
-	public static CreativeTabs createTab(final String name, String textureName)
-	{
-		creativeTabIconItemMap.put(name, new ItemCreativeTabIconProxy(textureName));
+		creativeTabIconItemMap.put(name, item);
 		return new CreativeTabs(name)
 		{
 			@Override

--- a/resources/assets/veganoption/models/item/creative_tab.json
+++ b/resources/assets/veganoption/models/item/creative_tab.json
@@ -1,0 +1,6 @@
+{
+	"parent": "item/generated",
+	"textures": {
+		"layer0": "veganoption:items/creative_tab"
+	}
+}


### PR DESCRIPTION
The Creative Tab stuff is handled in an IContentModule now, since we need proper registration for the item. And, since it HAS to be the first one executed, ContentModuleHandler.modules is now a LinkedHashMap, in order to preserve the order.
