### PR TITLE
Improve WAILA/TOP localization as discussed in #69

### DIFF
--- a/java/squeek/veganoption/blocks/BlockBasin.java
+++ b/java/squeek/veganoption/blocks/BlockBasin.java
@@ -1,8 +1,5 @@
 package squeek.veganoption.blocks;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoAccessor;
@@ -31,6 +28,8 @@ import squeek.veganoption.blocks.tiles.TileEntityBasin;
 import squeek.veganoption.helpers.LangHelper;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Optional.Interface(iface = "mcjty.theoneprobe.api.IProbeInfoAccessor", modid = "theoneprobe")
 public class BlockBasin extends Block implements IHollowBlock, IProbeInfoAccessor
@@ -336,7 +335,7 @@ public class BlockBasin extends Block implements IHollowBlock, IProbeInfoAccesso
 		TileEntityBasin basin = (TileEntityBasin) world.getTileEntity(data.getPos());
 		if (basin == null)
 			return;
-		probeInfo.text(LangHelper.translate("waila.basin." + (basin.isPowered() ? "open" : "closed")));
+		probeInfo.text(LangHelper.translate("info.basin." + (basin.isPowered() ? "open" : "closed")));
 
 	}
 }

--- a/java/squeek/veganoption/blocks/BlockComposter.java
+++ b/java/squeek/veganoption/blocks/BlockComposter.java
@@ -143,8 +143,8 @@ public class BlockComposter extends Block implements IProbeInfoAccessor
 			return;
 
 		if (composter.isComposting())
-			probeInfo.text(String.format("%s : %d%%", LangHelper.translate("waila.composter.composting"), (int) (composter.getCompostingPercent() * 100F)))
-				.text(String.format("%s : %.0f" + DEGREE_SYMBOL + "C", LangHelper.translate("waila.composter.temperature"), composter.getCompostTemperature()));
+			probeInfo.text(LangHelper.translate("waila.composter.composting", (int) (composter.getCompostingPercent() * 100F)))
+				.text(LangHelper.translate("waila.composter.temperature", (int) composter.getCompostTemperature()));
 		else
 			probeInfo.text(LangHelper.translate("waila.composter.empty"));
 	}

--- a/java/squeek/veganoption/blocks/BlockComposter.java
+++ b/java/squeek/veganoption/blocks/BlockComposter.java
@@ -31,7 +31,6 @@ public class BlockComposter extends Block implements IProbeInfoAccessor
 {
 	public static final AxisAlignedBB COMPOSTER_AABB = new AxisAlignedBB(0.0625F, 0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);
 	public static final PropertyDirection FACING = BlockHorizontal.FACING;
-	public static final String DEGREE_SYMBOL = "\u00B0";
 
 	public BlockComposter()
 	{
@@ -143,9 +142,9 @@ public class BlockComposter extends Block implements IProbeInfoAccessor
 			return;
 
 		if (composter.isComposting())
-			probeInfo.text(LangHelper.translate("waila.composter.composting", (int) (composter.getCompostingPercent() * 100F)))
-				.text(LangHelper.translate("waila.composter.temperature", (int) composter.getCompostTemperature()));
+			probeInfo.text(LangHelper.contextString("top", "composting", Math.round(composter.getCompostingPercent() * 100F)))
+				.text(LangHelper.contextString("top", "temperature", Math.round(composter.getCompostTemperature())));
 		else
-			probeInfo.text(LangHelper.translate("waila.composter.empty"));
+			probeInfo.text(LangHelper.translate("info.composter.empty"));
 	}
 }

--- a/java/squeek/veganoption/blocks/BlockComposter.java
+++ b/java/squeek/veganoption/blocks/BlockComposter.java
@@ -143,7 +143,7 @@ public class BlockComposter extends Block implements IProbeInfoAccessor
 
 		if (composter.isComposting())
 			probeInfo.text(LangHelper.contextString("top", "composting", Math.round(composter.getCompostingPercent() * 100F)))
-				.text(LangHelper.contextString("top", "temperature", Math.round(composter.getCompostTemperature())));
+				.text(LangHelper.contextString("top", "temperature", (int) Math.floor(composter.getCompostTemperature())));
 		else
 			probeInfo.text(LangHelper.translate("info.composter.empty"));
 	}

--- a/java/squeek/veganoption/blocks/BlockJutePlant.java
+++ b/java/squeek/veganoption/blocks/BlockJutePlant.java
@@ -1,7 +1,5 @@
 package squeek.veganoption.blocks;
 
-import java.util.Random;
-
 import mcjty.theoneprobe.Tools;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
@@ -18,7 +16,6 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.color.IItemColor;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -37,6 +34,7 @@ import squeek.veganoption.content.modules.Jute;
 import squeek.veganoption.helpers.LangHelper;
 
 import javax.annotation.Nullable;
+import java.util.Random;
 
 @Optional.Interface(iface = "mcjty.theoneprobe.api.IProbeInfoAccesor", modid = "theoneprobe")
 public class BlockJutePlant extends BlockBush implements IGrowable, IProbeInfoAccessor
@@ -233,9 +231,9 @@ public class BlockJutePlant extends BlockBush implements IGrowable, IProbeInfoAc
 
 		float growthValue = getGrowthPercent(world, data.getPos(), blockState) * 100F;
 		if (growthValue < 100)
-			probeInfo.text(LangHelper.translate("waila.growth", (int) growthValue));
+			probeInfo.text(LangHelper.contextString("top", "growth", Math.round(growthValue)));
 		else
-			probeInfo.text(LangHelper.translate("waila.growth.mature"));
+			probeInfo.text(LangHelper.contextString("top", "growth.mature"));
 	}
 
 	public static class ColorHandler implements IBlockColor, IItemColor

--- a/java/squeek/veganoption/blocks/BlockJutePlant.java
+++ b/java/squeek/veganoption/blocks/BlockJutePlant.java
@@ -34,6 +34,7 @@ import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import squeek.veganoption.content.modules.Jute;
+import squeek.veganoption.helpers.LangHelper;
 
 import javax.annotation.Nullable;
 
@@ -232,9 +233,9 @@ public class BlockJutePlant extends BlockBush implements IGrowable, IProbeInfoAc
 
 		float growthValue = getGrowthPercent(world, data.getPos(), blockState) * 100F;
 		if (growthValue < 100)
-			probeInfo.text(String.format("%s : %.0f %%", I18n.format("hud.msg.growth"), growthValue));
+			probeInfo.text(LangHelper.translate("waila.growth", (int) growthValue));
 		else
-			probeInfo.text(String.format("%s : %s", I18n.format("hud.msg.growth"), I18n.format("hud.msg.mature")));
+			probeInfo.text(LangHelper.translate("waila.growth.mature"));
 	}
 
 	public static class ColorHandler implements IBlockColor, IItemColor

--- a/java/squeek/veganoption/blocks/BlockRettable.java
+++ b/java/squeek/veganoption/blocks/BlockRettable.java
@@ -203,7 +203,7 @@ public class BlockRettable extends BlockHay implements IProbeInfoAccessor
 		else
 		{
 			if (canRet(world, data.getPos()))
-				probeInfo.text(LangHelper.translate("waila.retting") + " : " + (int) (rettingPercent * 100F) + "%");
+				probeInfo.text(LangHelper.translate("waila.retting", (int) (rettingPercent * 100F)));
 			else
 				probeInfo.text(LangHelper.translate("waila.retting.not.submerged"));
 		}

--- a/java/squeek/veganoption/blocks/BlockRettable.java
+++ b/java/squeek/veganoption/blocks/BlockRettable.java
@@ -1,7 +1,5 @@
 package squeek.veganoption.blocks;
 
-import java.util.Random;
-
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoAccessor;
@@ -21,7 +19,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.BiomeColorHelper;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -29,6 +26,7 @@ import squeek.veganoption.helpers.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Random;
 
 @Optional.Interface(iface = "mcjty.theoneprobe.api.IProbeInfoAccessor", modid = "theoneprobe")
 public class BlockRettable extends BlockHay implements IProbeInfoAccessor
@@ -199,13 +197,13 @@ public class BlockRettable extends BlockHay implements IProbeInfoAccessor
 	{
 		float rettingPercent = getRettingPercent(blockState);
 		if (rettingPercent >= 1)
-			probeInfo.text(LangHelper.translate("waila.retted"));
+			probeInfo.text(LangHelper.translate("info.retted"));
 		else
 		{
 			if (canRet(world, data.getPos()))
-				probeInfo.text(LangHelper.translate("waila.retting", (int) (rettingPercent * 100F)));
+				probeInfo.text(LangHelper.contextString("top", "retting", Math.round(rettingPercent * 100F)));
 			else
-				probeInfo.text(LangHelper.translate("waila.retting.not.submerged"));
+				probeInfo.text(LangHelper.translate("info.retting.not.submerged"));
 		}
 	}
 

--- a/java/squeek/veganoption/helpers/LangHelper.java
+++ b/java/squeek/veganoption/helpers/LangHelper.java
@@ -39,4 +39,9 @@ public class LangHelper
 	{
 		return I18n.hasKey(key);
 	}
+
+	public static String contextString(String format, String context, Object... params)
+	{
+		return translate(format + ".format", translate("context." + context + ".title", params), translate("context." + context + ".value", params), params);
+	}
 }

--- a/java/squeek/veganoption/integration/waila/ProviderBasin.java
+++ b/java/squeek/veganoption/integration/waila/ProviderBasin.java
@@ -37,9 +37,7 @@ public class ProviderBasin implements IWailaDataProvider
 
 		FluidTankInfo tankInfo = basin.fluidTank.getInfo();
 		if (tankInfo.fluid != null && tankInfo.fluid.amount > 0)
-		{
-			toolTip.add(tankInfo.fluid.getLocalizedName() + " : " + tankInfo.fluid.amount + "mB");
-		}
+			toolTip.add(LangHelper.translate("waila.fluid", tankInfo.fluid.getLocalizedName(), tankInfo.fluid.amount));
 		else
 			toolTip.add(LangHelper.translate("waila.basin.empty"));
 

--- a/java/squeek/veganoption/integration/waila/ProviderBasin.java
+++ b/java/squeek/veganoption/integration/waila/ProviderBasin.java
@@ -33,13 +33,13 @@ public class ProviderBasin implements IWailaDataProvider
 	public List<String> getWailaBody(ItemStack itemStack, List<String> toolTip, IWailaDataAccessor accessor, IWailaConfigHandler config)
 	{
 		TileEntityBasin basin = (TileEntityBasin) accessor.getTileEntity();
-		toolTip.add(LangHelper.translate(basin.isPowered() ? "waila.basin.open" : "waila.basin.closed"));
+		toolTip.add(LangHelper.translate(basin.isPowered() ? "info.basin.open" : "info.basin.closed"));
 
 		FluidTankInfo tankInfo = basin.fluidTank.getInfo();
 		if (tankInfo.fluid != null && tankInfo.fluid.amount > 0)
-			toolTip.add(LangHelper.translate("waila.fluid", tankInfo.fluid.getLocalizedName(), tankInfo.fluid.amount));
+			toolTip.add(LangHelper.contextString("waila", "fluid", tankInfo.fluid.getLocalizedName(), tankInfo.fluid.amount));
 		else
-			toolTip.add(LangHelper.translate("waila.basin.empty"));
+			toolTip.add(LangHelper.translate("info.basin.empty"));
 
 		return toolTip;
 	}

--- a/java/squeek/veganoption/integration/waila/ProviderComposter.java
+++ b/java/squeek/veganoption/integration/waila/ProviderComposter.java
@@ -1,6 +1,5 @@
 package squeek.veganoption.integration.waila;
 
-import java.util.List;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
@@ -10,9 +9,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import squeek.veganoption.blocks.BlockComposter;
 import squeek.veganoption.blocks.tiles.TileEntityComposter;
 import squeek.veganoption.helpers.LangHelper;
+
+import java.util.List;
 
 public class ProviderComposter implements IWailaDataProvider
 {
@@ -36,12 +36,12 @@ public class ProviderComposter implements IWailaDataProvider
 
 		if (tag.getLong("Start") == TileEntityComposter.NOT_COMPOSTING)
 		{
-			toolTip.add(LangHelper.translate("waila.composter.empty"));
+			toolTip.add(LangHelper.translate("info.composter.empty"));
 		}
 		else
 		{
-			toolTip.add(LangHelper.translate("waila.composter.composting", (int) (tag.getFloat("Compost") * 100F)));
-			toolTip.add(LangHelper.translate("waila.composter.temperature", (int) tag.getFloat("Temperature")));
+			toolTip.add(LangHelper.contextString("waila", "composting", Math.round(tag.getFloat("Compost") * 100F)));
+			toolTip.add(LangHelper.contextString("waila", "temperature", Math.round(tag.getFloat("Temperature"))));
 		}
 		return toolTip;
 	}

--- a/java/squeek/veganoption/integration/waila/ProviderComposter.java
+++ b/java/squeek/veganoption/integration/waila/ProviderComposter.java
@@ -41,7 +41,7 @@ public class ProviderComposter implements IWailaDataProvider
 		else
 		{
 			toolTip.add(LangHelper.contextString("waila", "composting", Math.round(tag.getFloat("Compost") * 100F)));
-			toolTip.add(LangHelper.contextString("waila", "temperature", Math.round(tag.getFloat("Temperature"))));
+			toolTip.add(LangHelper.contextString("waila", "temperature", (int) Math.floor(tag.getFloat("Temperature"))));
 		}
 		return toolTip;
 	}

--- a/java/squeek/veganoption/integration/waila/ProviderComposter.java
+++ b/java/squeek/veganoption/integration/waila/ProviderComposter.java
@@ -40,8 +40,8 @@ public class ProviderComposter implements IWailaDataProvider
 		}
 		else
 		{
-			toolTip.add(String.format("%s : %d%%", LangHelper.translate("waila.composter.composting"), (int) (tag.getFloat("Compost") * 100f)));
-			toolTip.add(String.format("%s : %.0f" + BlockComposter.DEGREE_SYMBOL + "C", LangHelper.translate("waila.composter.temperature"), tag.getFloat("Temperature")));
+			toolTip.add(LangHelper.translate("waila.composter.composting", (int) (tag.getFloat("Compost") * 100F)));
+			toolTip.add(LangHelper.translate("waila.composter.temperature", (int) tag.getFloat("Temperature")));
 		}
 		return toolTip;
 	}

--- a/java/squeek/veganoption/integration/waila/ProviderJutePlant.java
+++ b/java/squeek/veganoption/integration/waila/ProviderJutePlant.java
@@ -12,6 +12,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import squeek.veganoption.blocks.BlockJutePlant;
+import squeek.veganoption.helpers.LangHelper;
 
 public class ProviderJutePlant implements IWailaDataProvider
 {
@@ -34,9 +35,9 @@ public class ProviderJutePlant implements IWailaDataProvider
 		{
 			float growthValue = ((BlockJutePlant) accessor.getBlock()).getGrowthPercent(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState()) * 100.0F;
 			if (growthValue < 100)
-				toolTip.add(String.format("%s : %.0f %%", I18n.format("hud.msg.growth"), growthValue));
+				toolTip.add(LangHelper.translate("waila.growth", (int) growthValue));
 			else
-				toolTip.add(String.format("%s : %s", I18n.format("hud.msg.growth"), I18n.format("hud.msg.mature")));
+				toolTip.add(LangHelper.translate("waila.growth.mature"));
 		}
 
 		return toolTip;

--- a/java/squeek/veganoption/integration/waila/ProviderJutePlant.java
+++ b/java/squeek/veganoption/integration/waila/ProviderJutePlant.java
@@ -1,18 +1,18 @@
 package squeek.veganoption.integration.waila;
 
-import java.util.List;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import squeek.veganoption.blocks.BlockJutePlant;
 import squeek.veganoption.helpers.LangHelper;
+
+import java.util.List;
 
 public class ProviderJutePlant implements IWailaDataProvider
 {
@@ -35,9 +35,9 @@ public class ProviderJutePlant implements IWailaDataProvider
 		{
 			float growthValue = ((BlockJutePlant) accessor.getBlock()).getGrowthPercent(accessor.getWorld(), accessor.getPosition(), accessor.getBlockState()) * 100.0F;
 			if (growthValue < 100)
-				toolTip.add(LangHelper.translate("waila.growth", (int) growthValue));
+				toolTip.add(LangHelper.contextString("waila", "growth", Math.round(growthValue)));
 			else
-				toolTip.add(LangHelper.translate("waila.growth.mature"));
+				toolTip.add(LangHelper.contextString("waila", "growth.mature"));
 		}
 
 		return toolTip;

--- a/java/squeek/veganoption/integration/waila/ProviderRettable.java
+++ b/java/squeek/veganoption/integration/waila/ProviderRettable.java
@@ -37,7 +37,7 @@ public class ProviderRettable implements IWailaDataProvider
 		else
 		{
 			if (blockRettable.canRet(accessor.getWorld(), accessor.getPosition()))
-				toolTip.add(LangHelper.translate("waila.retting") + " : " + (int) (rettingPercent * 100f) + "%");
+				toolTip.add(LangHelper.translate("waila.retting", (int) (rettingPercent * 100F)));
 			else
 				toolTip.add(LangHelper.translate("waila.retting.not.submerged"));
 		}

--- a/java/squeek/veganoption/integration/waila/ProviderRettable.java
+++ b/java/squeek/veganoption/integration/waila/ProviderRettable.java
@@ -1,6 +1,5 @@
 package squeek.veganoption.integration.waila;
 
-import java.util.List;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
@@ -12,6 +11,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import squeek.veganoption.blocks.BlockRettable;
 import squeek.veganoption.helpers.LangHelper;
+
+import java.util.List;
 
 public class ProviderRettable implements IWailaDataProvider
 {
@@ -33,13 +34,13 @@ public class ProviderRettable implements IWailaDataProvider
 		BlockRettable blockRettable = (BlockRettable) accessor.getBlock();
 		float rettingPercent = BlockRettable.getRettingPercent(accessor.getWorld(), accessor.getPosition());
 		if (rettingPercent >= 1)
-			toolTip.add(LangHelper.translate("waila.retted"));
+			toolTip.add(LangHelper.translate("info.retted"));
 		else
 		{
 			if (blockRettable.canRet(accessor.getWorld(), accessor.getPosition()))
-				toolTip.add(LangHelper.translate("waila.retting", (int) (rettingPercent * 100F)));
+				toolTip.add(LangHelper.contextString("waila", "retting", Math.round(rettingPercent * 100F)));
 			else
-				toolTip.add(LangHelper.translate("waila.retting.not.submerged"));
+				toolTip.add(LangHelper.translate("info.retting.not.submerged"));
 		}
 		return toolTip;
 	}

--- a/resources/assets/veganoption/lang/en_US.lang
+++ b/resources/assets/veganoption/lang/en_US.lang
@@ -38,9 +38,11 @@ item.VeganOption.juteFibre.nei.crafting=%1$s is obtained by breaking fully rette
 item.VeganOption.juteSeeds.name=Jute Seeds
 item.VeganOption.juteSeeds.nei.usage=An alternative method of propagating a [[minecraft:double_plant:3]]. Can be planted on dirt, grass, or farmland.
 tile.VeganOption.jutePlant.name=Jute
-VeganOption.waila.retting=Retting
+VeganOption.waila.retting=Retting : %d%%
 VeganOption.waila.retting.not.submerged=Needs to be submerged in water
 VeganOption.waila.retted=Retted
+VeganOption.waila.growth=Growth : %d %%
+VeganOption.waila.growth.mature=Growth : Mature
 
 # Burlap
 item.VeganOption.burlap.name=Burlap
@@ -133,8 +135,8 @@ tile.VeganOption.compost.nei.usage=%1$s provides passive improvement to adjacent
 item.VeganOption.fertilizer.name=Fertilizer
 item.VeganOption.fertilizer.nei.usage=%1$s is a [[minecraft:dye:15]] alternative.
 VeganOption.waila.composter.empty=Empty
-VeganOption.waila.composter.composting=Composting
-VeganOption.waila.composter.temperature=Temperature
+VeganOption.waila.composter.composting=Composting : %d%%
+VeganOption.waila.composter.temperature=Temperature : %d°C
 VeganOption.gui.composter.tumble=Tumble Composter
 VeganOption.gui.composter.tumble.desc=Every time the composter is tumbled, it will lose heat initially, but will gain more heat in the long run. The composter should be tumbled about twice every Minecraft day.
 VeganOption.gui.composter.temperature=Temperature: %s
@@ -203,6 +205,7 @@ tile.VeganOption.basin.nei.usage=%1$s is a simple fluid tank that holds up to 1 
 VeganOption.waila.basin.empty=Empty
 VeganOption.waila.basin.open=Open
 VeganOption.waila.basin.closed=Closed
+VeganOption.waila.fluid=%s : %dmB
 
 # Seitan
 item.VeganOption.wheatFlour.name=Wheat Flour

--- a/resources/assets/veganoption/lang/en_US.lang
+++ b/resources/assets/veganoption/lang/en_US.lang
@@ -29,6 +29,28 @@
 # Creative Tab
 itemGroup.VeganOption=The Vegan Option
 
+# WAILA and The One Probe strings
+VeganOption.waila.format=%1$s : %2$s
+VeganOption.top.format=%1$s: %2$s
+VeganOption.context.growth.title=Growth
+VeganOption.context.growth.value=%1$d%%
+VeganOption.context.growth.mature.title=Growth
+VeganOption.context.growth.mature.value=Mature
+VeganOption.context.retting.title=Retting
+VeganOption.context.retting.value=%1$d%%
+VeganOption.info.retting.not.submerged=Needs to be submerged in water
+VeganOption.info.retted=Retted
+VeganOption.info.composter.empty=Empty
+VeganOption.context.composting.title=Composting
+VeganOption.context.composting.value=%1$d%%
+VeganOption.context.temperature.title=Temperature
+VeganOption.context.temperature.value=%1$d°C
+VeganOption.info.basin.empty=Empty
+VeganOption.info.basin.open=Open
+VeganOption.info.basin.closed=Closed
+VeganOption.context.fluid.title=%1$s
+VeganOption.context.fluid.value=%2$dmB
+
 # Jute
 tile.VeganOption.juteBundled.name=Bundled Jute
 tile.VeganOption.juteBundled.nei.usage=In order to extract the [[VeganOption:juteFibre]], %1$s must be first be retted (submerged in water). [[minecraft:comparator]] output is based on the current retting stage of the %1$s.
@@ -38,11 +60,6 @@ item.VeganOption.juteFibre.nei.crafting=%1$s is obtained by breaking fully rette
 item.VeganOption.juteSeeds.name=Jute Seeds
 item.VeganOption.juteSeeds.nei.usage=An alternative method of propagating a [[minecraft:double_plant:3]]. Can be planted on dirt, grass, or farmland.
 tile.VeganOption.jutePlant.name=Jute
-VeganOption.waila.retting=Retting : %d%%
-VeganOption.waila.retting.not.submerged=Needs to be submerged in water
-VeganOption.waila.retted=Retted
-VeganOption.waila.growth=Growth : %d %%
-VeganOption.waila.growth.mature=Growth : Mature
 
 # Burlap
 item.VeganOption.burlap.name=Burlap
@@ -134,9 +151,6 @@ tile.VeganOption.compost.name=Compost
 tile.VeganOption.compost.nei.usage=%1$s provides passive improvement to adjacent [[minecraft:farmland]].
 item.VeganOption.fertilizer.name=Fertilizer
 item.VeganOption.fertilizer.nei.usage=%1$s is a [[minecraft:dye:15]] alternative.
-VeganOption.waila.composter.empty=Empty
-VeganOption.waila.composter.composting=Composting : %d%%
-VeganOption.waila.composter.temperature=Temperature : %d°C
 VeganOption.gui.composter.tumble=Tumble Composter
 VeganOption.gui.composter.tumble.desc=Every time the composter is tumbled, it will lose heat initially, but will gain more heat in the long run. The composter should be tumbled about twice every Minecraft day.
 VeganOption.gui.composter.temperature=Temperature: %s
@@ -202,10 +216,6 @@ item.VeganOption.dollsEye.nei.crafting={item.VeganOption.dollsEye.nei.common}\n\
 # Basin
 tile.VeganOption.basin.name=Basin
 tile.VeganOption.basin.nei.usage=%1$s is a simple fluid tank that holds up to 1 buckets worth of fluid. By default, it has a lid, but when a redstone signal is applied, the lid is removed and it acts as a fluid hopper (fluid blocks will flow into it).\n\nWhen container items (buckets, bottles, etc) are dropped inside an open %1$s, they will be filled with the fluid inside the %1$s if possible.
-VeganOption.waila.basin.empty=Empty
-VeganOption.waila.basin.open=Open
-VeganOption.waila.basin.closed=Closed
-VeganOption.waila.fluid=%s : %dmB
 
 # Seitan
 item.VeganOption.wheatFlour.name=Wheat Flour


### PR DESCRIPTION
There are a couple cases where it may have made more sense to use `Math.round` instead of int typecasting, but I figured it's such an insignificant detail (68º vs 69º really is not crucial for composting effectively) that the significant performance hit (for Java 6 and below, see _[What is the most efficient way to round a float value to the nearest integer in java?](http://stackoverflow.com/questions/12091014)_) was not worth it.

I double checked and, although I think some of the formatting to begin with was wonky (weird spaces before and after `:` and `%`), it looks identical to how it did before.
