### PR TITLE
Egg fun

### DIFF
--- a/java/squeek/veganoption/content/Modifiers.java
+++ b/java/squeek/veganoption/content/Modifiers.java
@@ -2,6 +2,7 @@ package squeek.veganoption.content;
 
 import squeek.veganoption.content.modifiers.CraftingModifier;
 import squeek.veganoption.content.modifiers.DropsModifier;
+import squeek.veganoption.content.modifiers.EggModifier;
 import squeek.veganoption.content.modifiers.RecipeModifier;
 
 public class Modifiers
@@ -9,4 +10,5 @@ public class Modifiers
 	public static final RecipeModifier recipes = new RecipeModifier();
 	public static final DropsModifier drops = new DropsModifier();
 	public static final CraftingModifier crafting = new CraftingModifier();
+	public static final EggModifier eggs = new EggModifier();
 }

--- a/java/squeek/veganoption/content/modifiers/EggModifier.java
+++ b/java/squeek/veganoption/content/modifiers/EggModifier.java
@@ -1,0 +1,97 @@
+package squeek.veganoption.content.modifiers;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.RayTraceResult;
+import squeek.veganoption.entities.EntityPlasticEgg;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EggModifier
+{
+	/**
+	 * A generic EggModifier for when the ItemStack being searched is null. It does is ensured to do nothing.
+	 */
+	private static final EggModifier DO_NOTHING_MODIFIER = new EggModifier();
+	private static final Map<ItemStackMatcher, EggModifier> modifiers = new HashMap<ItemStackMatcher, EggModifier>();
+
+	public void addItem(ItemStack stack, EggModifier modifier)
+	{
+		addItem(new ItemStackMatcher(stack), modifier);
+	}
+
+	public void addItem(ItemStackMatcher matcher, EggModifier modifier)
+	{
+		modifiers.put(matcher, modifier);
+	}
+
+	/**
+	 * Finds an EggModifier that matches the provided ItemStack (see {@link ItemStackMatcher}). If it does not find a match, it will
+	 * instantiate a new {@link EggModifierDropItem}, add it to the modifier registry, and return it. Never null.
+	 */
+	@Nonnull
+	public EggModifier findModifierForItemStack(ItemStack value)
+	{
+		if (value == null) return DO_NOTHING_MODIFIER;
+
+		for (Map.Entry<ItemStackMatcher, EggModifier> entry : modifiers.entrySet())
+		{
+			if (entry.getKey().matches(value)) return entry.getValue();
+		}
+
+		EggModifier modifier = new EggModifierDropItem(value);
+		modifiers.put(new ItemStackMatcher(value), modifier);
+		return modifier;
+	}
+
+	/**
+	 * Called when the plastic egg collides with an entity.
+	 * @param rayTraceResult See {@link EntityThrowable#onImpact(RayTraceResult)}
+	 * @param eggEntity The egg that collided
+	 */
+	public void onEntityCollision(RayTraceResult rayTraceResult, EntityPlasticEgg eggEntity)
+	{
+	}
+
+	/**
+	 * Called before the egg is set to dead. See {@link #onEntityCollision(RayTraceResult, EntityPlasticEgg)} for parameters.
+	 */
+	public void onImpactGeneric(RayTraceResult rayTraceResult, EntityPlasticEgg eggEntity)
+	{
+	}
+
+	public static class ItemStackMatcher
+	{
+		private final ItemStack toMatch;
+
+		public ItemStackMatcher(ItemStack toMatch)
+		{
+			this.toMatch = toMatch;
+		}
+
+		public boolean matches(ItemStack value)
+		{
+			return ItemStack.areItemStacksEqual(toMatch, value);
+		}
+	}
+
+	public static class EggModifierDropItem extends EggModifier
+	{
+		private final ItemStack toDrop;
+
+		public EggModifierDropItem(ItemStack toDrop)
+		{
+			this.toDrop = toDrop;
+		}
+
+		@Override
+		public void onImpactGeneric(RayTraceResult rayTraceResult, EntityPlasticEgg eggEntity)
+		{
+			EntityItem item = new EntityItem(eggEntity.worldObj, eggEntity.posX, eggEntity.posY, eggEntity.posZ, toDrop);
+			eggEntity.worldObj.spawnEntityInWorld(item);
+		}
+	}
+}

--- a/java/squeek/veganoption/content/modules/Egg.java
+++ b/java/squeek/veganoption/content/modules/Egg.java
@@ -8,6 +8,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.fml.client.registry.IRenderFactory;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
@@ -15,17 +16,20 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.RecipeSorter;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import squeek.veganoption.ModInfo;
 import squeek.veganoption.VeganOption;
 import squeek.veganoption.content.ContentHelper;
 import squeek.veganoption.content.IContentModule;
 import squeek.veganoption.content.Modifiers;
+import squeek.veganoption.content.modifiers.EggModifier;
+import squeek.veganoption.content.recipes.EggRecipe;
 import squeek.veganoption.content.recipes.PistonCraftingRecipe;
 import squeek.veganoption.content.registry.PistonCraftingRegistry;
 import squeek.veganoption.entities.EntityPlasticEgg;
 import squeek.veganoption.items.ItemFoodContainered;
-import squeek.veganoption.items.ItemThrowableGeneric;
+import squeek.veganoption.items.ItemPlasticEgg;
 
 public class Egg implements IContentModule
 {
@@ -51,13 +55,15 @@ public class Egg implements IContentModule
 			.setRegistryName(ModInfo.MODID_LOWER, "potato_starch");
 		GameRegistry.register(potatoStarch);
 
-		plasticEgg = new ItemThrowableGeneric(EntityPlasticEgg.class)
+		plasticEgg = new ItemPlasticEgg()
 			.setUnlocalizedName(ModInfo.MODID + ".plasticEgg")
 			.setCreativeTab(VeganOption.creativeTab)
 			.setRegistryName(ModInfo.MODID_LOWER, "plastic_egg");
 		GameRegistry.register(plasticEgg);
 
 		EntityRegistry.registerModEntity(EntityPlasticEgg.class, "plasticEgg", ContentHelper.ENTITYID_PLASTIC_EGG, ModInfo.MODID, 80, 1, true);
+
+		RecipeSorter.register(ModInfo.MODID_LOWER + ":egg_recipe", EggRecipe.class, RecipeSorter.Category.SHAPELESS, "after:minecraft:shapeless");
 	}
 
 	@SideOnly(Side.CLIENT)
@@ -119,6 +125,15 @@ public class Egg implements IContentModule
 		PistonCraftingRegistry.register(new PistonCraftingRecipe(new ItemStack(potatoStarch), Items.POTATO));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(plasticEgg), " o ", "o o", " o ", 'o', ContentHelper.plasticOreDict));
+		GameRegistry.addRecipe(new EggRecipe());
+		Modifiers.eggs.addItem(new ItemStack(Items.GUNPOWDER), new EggModifier()
+		{
+			@Override
+			public void onImpactGeneric(RayTraceResult rayTraceResult, EntityPlasticEgg eggEntity)
+			{
+				eggEntity.worldObj.createExplosion(eggEntity.getThrower(), eggEntity.posX, eggEntity.posY, eggEntity.posZ, 2F, true);
+			}
+		});
 	}
 
 	@Override

--- a/java/squeek/veganoption/content/recipes/EggRecipe.java
+++ b/java/squeek/veganoption/content/recipes/EggRecipe.java
@@ -1,0 +1,79 @@
+package squeek.veganoption.content.recipes;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import squeek.veganoption.content.modules.Egg;
+
+import javax.annotation.Nullable;
+
+public class EggRecipe implements IRecipe
+{
+	@Override
+	public boolean matches(InventoryCrafting inv, World worldIn)
+	{
+		return getItemToEgg(inv) != null;
+	}
+
+	@Nullable
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting inv)
+	{
+		ItemStack toEgg = getItemToEgg(inv);
+		if (toEgg != null)
+		{
+			ItemStack eggStack = new ItemStack(Egg.plasticEgg, 1);
+			NBTTagCompound nbt = new NBTTagCompound();
+			NBTTagCompound egg = toEgg.writeToNBT(new NBTTagCompound());
+			nbt.setTag("ContainedItem", egg);
+			eggStack.setTagCompound(nbt);
+			return eggStack;
+		}
+		return null;
+	}
+
+	@Nullable
+	private ItemStack getItemToEgg(InventoryCrafting inv)
+	{
+		ItemStack output = null;
+		int eggs = 0;
+		int nonEggs = 0;
+		for (int i = 0; i < inv.getSizeInventory(); i++)
+		{
+			ItemStack itemStack = inv.getStackInSlot(i);
+			if (itemStack != null) {
+				if (itemStack.getItem() == Egg.plasticEgg)
+					eggs++;
+				else
+				{
+					nonEggs++;
+					if (output == null)
+						output = itemStack.copy();
+				}
+			}
+		}
+
+		return eggs == 1 && nonEggs == 1 ? output : null;
+	}
+
+	@Override
+	public int getRecipeSize()
+	{
+		return 2;
+	}
+
+	@Nullable
+	@Override
+	public ItemStack getRecipeOutput()
+	{
+		return null;
+	}
+
+	@Override
+	public ItemStack[] getRemainingItems(InventoryCrafting inv)
+	{
+		return new ItemStack[inv.getSizeInventory()];
+	}
+}

--- a/java/squeek/veganoption/entities/EntityPlasticEgg.java
+++ b/java/squeek/veganoption/entities/EntityPlasticEgg.java
@@ -2,15 +2,20 @@ package squeek.veganoption.entities;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
+import squeek.veganoption.content.Modifiers;
+import squeek.veganoption.content.modifiers.EggModifier;
 import squeek.veganoption.network.MessageFX;
 import squeek.veganoption.network.NetworkHandler;
 
 public class EntityPlasticEgg extends EntityThrowable
 {
+	private ItemStack insideEgg;
+
 	public EntityPlasticEgg(World world)
 	{
 		super(world);
@@ -26,16 +31,32 @@ public class EntityPlasticEgg extends EntityThrowable
 		super(world, x, y, z);
 	}
 
+	public EntityPlasticEgg(ItemStack insideEgg, World world, double x, double y, double z)
+	{
+		super(world, x, y, z);
+		this.insideEgg = insideEgg;
+	}
+
+	public EntityPlasticEgg(ItemStack insideEgg, World world, EntityLivingBase thrower)
+	{
+		super(world, thrower);
+		this.insideEgg = insideEgg;
+	}
+
 	@Override
 	protected void onImpact(RayTraceResult rayTraceResult)
 	{
+		EggModifier eggModifier = Modifiers.eggs.findModifierForItemStack(insideEgg);
+
 		if (rayTraceResult.entityHit != null)
 		{
+			eggModifier.onEntityCollision(rayTraceResult, this);
 			rayTraceResult.entityHit.attackEntityFrom(DamageSource.causeThrownDamage(this, getThrower()), 0.0F);
 		}
 
 		if (!worldObj.isRemote)
 		{
+			eggModifier.onImpactGeneric(rayTraceResult, this);
 			NetworkRegistry.TargetPoint target = new NetworkRegistry.TargetPoint(dimension, posX, posY, posZ, 80);
 			NetworkHandler.channel.sendToAllAround(new MessageFX(posX, posY, posZ, MessageFX.FX.PLASTIC_EGG_BREAK), target);
 			setDead();

--- a/java/squeek/veganoption/items/ItemPlasticEgg.java
+++ b/java/squeek/veganoption/items/ItemPlasticEgg.java
@@ -1,0 +1,52 @@
+package squeek.veganoption.items;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import squeek.veganoption.entities.EntityPlasticEgg;
+import squeek.veganoption.helpers.LangHelper;
+
+import java.util.List;
+
+public class ItemPlasticEgg extends ItemThrowableGeneric
+{
+	public ItemPlasticEgg()
+	{
+		super(EntityPlasticEgg.class);
+	}
+
+	@Override
+	public EntityThrowable getNewThrownEntity(ItemStack thrownItem, World world, EntityLivingBase thrower)
+	{
+		if (thrownItem.hasTagCompound() && thrownItem.getTagCompound().hasKey("ContainedItem"))
+			return new EntityPlasticEgg(getContainedItem(thrownItem), world, thrower);
+
+		return super.getNewThrownEntity(thrownItem, world, thrower);
+	}
+
+	@Override
+	public EntityThrowable getNewThrownEntity(ItemStack thrownItem, World world, double x, double y, double z)
+	{
+		if (thrownItem.hasTagCompound() && thrownItem.getTagCompound().hasKey("ContainedItem"))
+			return new EntityPlasticEgg(getContainedItem(thrownItem), world, x, y, z);
+
+		return super.getNewThrownEntity(thrownItem, world, x, y, z);
+	}
+
+	@Override
+	public void addInformation(ItemStack stack, EntityPlayer playerIn, List<String> tooltip, boolean advanced)
+	{
+		if (stack.hasTagCompound() && stack.getTagCompound().hasKey("ContainedItem"))
+		{
+			ItemStack containedItem = getContainedItem(stack);
+			tooltip.add(LangHelper.translateRaw(getUnlocalizedName() + ".tooltip", LangHelper.translateRaw(containedItem.getItem().getUnlocalizedName(containedItem) + ".name")));
+		}
+	}
+
+	private ItemStack getContainedItem(ItemStack self)
+	{
+		return ItemStack.loadItemStackFromNBT(self.getTagCompound().getCompoundTag("ContainedItem"));
+	}
+}

--- a/java/squeek/veganoption/items/ItemThrowableGeneric.java
+++ b/java/squeek/veganoption/items/ItemThrowableGeneric.java
@@ -80,7 +80,7 @@ public class ItemThrowableGeneric extends Item
 
 		if (!world.isRemote)
 		{
-			EntityThrowable entity = getNewThrownEntity(world, player);
+			EntityThrowable entity = getNewThrownEntity(itemStack, world, player);
 			entity.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, 0.0F, throwSpeed, 1.0F);
 			world.spawnEntityInWorld(entity);
 		}
@@ -88,7 +88,7 @@ public class ItemThrowableGeneric extends Item
 		return ActionResult.newResult(EnumActionResult.SUCCESS, itemStack);
 	}
 
-	public EntityThrowable getNewThrownEntity(World world, EntityLivingBase thrower)
+	public EntityThrowable getNewThrownEntity(ItemStack thrownItem, World world, EntityLivingBase thrower)
 	{
 		try
 		{
@@ -101,7 +101,7 @@ public class ItemThrowableGeneric extends Item
 		}
 	}
 
-	public EntityThrowable getNewThrownEntity(World world, double x, double y, double z)
+	public EntityThrowable getNewThrownEntity(ItemStack thrownItem, World world, double x, double y, double z)
 	{
 		try
 		{
@@ -131,7 +131,7 @@ public class ItemThrowableGeneric extends Item
 		@Override
 		protected IProjectile getProjectileEntity(World world, IPosition position, ItemStack stack)
 		{
-			return itemThrowableGeneric.getNewThrownEntity(world, position.getX(), position.getY(), position.getZ());
+			return itemThrowableGeneric.getNewThrownEntity(stack, world, position.getX(), position.getY(), position.getZ());
 		}
 	}
 }

--- a/resources/assets/veganoption/lang/en_US.lang
+++ b/resources/assets/veganoption/lang/en_US.lang
@@ -117,6 +117,7 @@ item.VeganOption.potatoStarch.name=Potato Starch
 item.VeganOption.plasticEgg.name=Plastic Egg
 item.VeganOption.plasticEgg.nei.usage=A %1$s is an [[minecraft:egg]] alternative for non-baking purposes.
 entity.VeganOption.plasticEgg.name=Plastic Egg
+item.VeganOption.plasticEgg.tooltip=Contains %s
 
 # Resin
 item.VeganOption.resin.name=Resin


### PR DESCRIPTION
Add ability to put items inside plastic eggs, with a Modifier system for custom impact behavior.

Add a single impact behavior for Gunpowder to explode. Not really sure what else to add.

#45 

In order to add an item to an egg, you shapelessly craft them together. It adds a "Contains <Item>" tooltip. Registering custom EggModifiers will modify the behavior of a plastic egg depending on what is contained in it. Right now, there's just gunpowder, which explodes.